### PR TITLE
aceEditor for basic editor construction

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -25,7 +25,7 @@
 
 		<script>
 			requirejs(['../src/js/frontend/config'],function(){
-				requirejs(['jQuery','ace','editor','app','user','home'],
+				requirejs(['jQuery','ace','aceEditor','app','user','home'],
 				function (app, home) {
 					var app = new App(), user = new User(), home = new Home();
 					app.init();

--- a/src/js/frontend/config.js
+++ b/src/js/frontend/config.js
@@ -15,6 +15,7 @@ requirejs.config({
         // controller
         app: 'controller/app',
         // core
+        aceEditor: 'controller/core/aceEditor',
         api: 'controller/core/api',
         cart: 'controller/core/cart',
         editor: 'controller/core/editor',

--- a/src/js/frontend/controller/core/aceEditor.js
+++ b/src/js/frontend/controller/core/aceEditor.js
@@ -1,0 +1,53 @@
+class aceEditor {
+	init(data) {
+		this.data = data;
+		if(data.id) {
+			this.buildEditor();
+		}
+		else {
+			jQuery('.edx-editor').addClass('edx-wrapper').html('<div class="edx-editor-error">ERROR</div>');
+		}
+	}
+
+	buildEditor() {
+
+		let data, editor, defaults, theme, mode, wrap, margin, code, readonly, shadow, length;
+
+		// Editor Data
+		data = this.data;
+
+		// Editor Defaults
+		defaults = {
+			'theme':'ace/theme/monokai',
+			'mode':'ace/mode/html',
+			'code': '',
+			'wrap':true,
+			'margin':false,
+			'focus':true,
+			'readonly':false,
+      'shadow':true
+		};
+
+    // data.setting.length will throw if data.setting doesn't exist; use === undefined
+    // ternary operators use (conditional)?ifTrue:ifFalse
+		theme = data.theme === undefined ? defaults.theme : data.theme; // set theme
+		mode = data.mode === undefined ? defaults.mode : data.mode; // set mode
+		wrap = data.wrap === undefined ? defaults.wrap : data.wrap; // set wrap
+		margin = data.margin === undefined ? defaults.margin : data.margin; // set margin
+		code = data.code === undefined ? defaults.code : data.code; // set code
+		readonly = data.readonly === undefined ? defaults.readonly : data.readonly; // set readonly
+		shadow = data.shadow === undefined ? defaults.shadow : data.shadow; // set template
+
+		editor = ace.edit(data.id);
+		editor.setTheme(theme);
+		editor.session.setMode(mode);
+		editor.session.setUseWrapMode(wrap);
+		editor.setShowPrintMargin(margin);
+		editor.setValue(code);
+		editor.setReadOnly(readonly);
+
+		if(data.focus) { length = editor.session.getLength(); editor.gotoLine(length); editor.focus(); }
+		if(data.shadow) { jQuery('.edx-editor-app').addClass('shadow'); }
+
+	}
+}

--- a/src/js/frontend/controller/pages/home.js
+++ b/src/js/frontend/controller/pages/home.js
@@ -26,7 +26,7 @@ class Home {
 	}
 
 	editor() {
-		let container, content, code, editor = new Editor();
+		let container, content, code, editor = new aceEditor();
 		container = jQuery('.edx-section-editor');
 		content = 	`<div class="edx-angled-section-wrapper edx-container">
 						<div class="edx-editor-container">
@@ -45,7 +45,7 @@ class Home {
 <html lang="en">
 	<head>
 		<title>educoded</title>
-		
+
 		<!-- Main CSS -->
 		<link rel="stylesheet" type="text/css" href="../src/css/frontend/main.css">
 
@@ -57,7 +57,7 @@ class Home {
 
 		<script>
 			requirejs(['../src/js/frontend/config'],function(){
-				requirejs(['jQuery','ace','editor','app','user','home'],
+				requirejs(['jQuery','ace','aceEditor','app','user','home'],
 				function (app, home) {
 					var app = new App(), user = new User(), home = new Home();
 					app.init();
@@ -79,7 +79,7 @@ class Home {
 			'wrap':true,
 			'margin':false,
 			'focus':true,
-			'read-only':false,
+			'readonly':false,
 			'shadow':true,
 			'style':{
 				'font-size':'11px'


### PR DESCRIPTION
This pull has the following changes:

- aceEditor was added to core, and added to config
- home.html and .js now point to aceEditor instead of Editor

inside home.js:

- 'read-only' was returning undefined. renamed to 'readonly' to match aceEditor defaults


inside aceEditor:

- some ternary operators were backwards
- .length cannot be called on undefined objects -  reverted back to === undefined
- the tab switching functionality, saveEditor loadEditor, etc were removed as they were just console logs and will not apply to simple editors generated by this class.